### PR TITLE
Der Frankfurt Perlmongers e.V. weist Umsatzsteuer aus

### DIFF
--- a/actdocs/payment/invoice
+++ b/actdocs/payment/invoice
@@ -95,7 +95,7 @@ Homepage: http://frankfurt.pm<br>
             <tr valign="top"> <td> Verwendungszweck</td><td>DPW 2016 N&uuml;rnberg<br/>BestellNr.: <em>Bestellnummer</em><br/><em>Nachname, Vorname</em></td></tr>
             <tr>
 	      <td colspan="2">
-	      <p>Der Frankfurt Perlmongers e.V. ist ein gemeinn&uuml;tziger Verein weisst keine USt. aus.</p>
+	      <p>Der Frankfurt Perlmongers e.V. ist ein gemeinn&uuml;tziger Verein.</p>
 	    </tr>
           </table>
         </td>


### PR DESCRIPTION
Wir weisen Umsatzsteuer aus, also sollte das auch auf unseren Dokumenten nicht anders stehen...
